### PR TITLE
[OT] Fix interpolation string issue with jslint at build time

### DIFF
--- a/src/wwwroot/template-editor/adapterService.js
+++ b/src/wwwroot/template-editor/adapterService.js
@@ -358,7 +358,7 @@
     function getCampaign(id, useEditorAsTemplate) {
       traceAdapterCall(getCampaign, arguments);
       // TODO This is a temporary url reference to the current backend syntax call
-      return $http.get(`${RELAY_CONFIG.baseUrl}/accounts/${loginSession.accountId}/templates/${id}`, {
+      return $http.get(RELAY_CONFIG.baseUrl + '/accounts/' + loginSession.accountId + '/templates/' + id, {
         headers: {
           'Authorization': 'Bearer '+ apiToken
         }


### PR DESCRIPTION
## Background
  
Jslint fails on build time using interpolation literal in get method and url path parameter
  
## Changes done
  
Change interpolation literal to concatenation
  
## Pending to be done
  
N/A
  
## Notes
  
The stack trace throws an ugly message to locate the error.
 
## Demo
 
Jslint error stack trace:
```js
events.js:183
      throw er; // Unhandled 'error' event
      ^
Error
    at new JS_Parse_Error (D:\MakingSense\relay-webapp\src\node_modules\gulp-uglify\node_modules\uglify-js\lib\parse.js:196:18)
    at js_error (D:\MakingSense\relay-webapp\src\node_modules\gulp-uglify\node_modules\uglify-js\lib\parse.js:204:11)
    at parse_error (D:\MakingSense\relay-webapp\src\node_modules\gulp-uglify\node_modules\uglify-js\lib\parse.js:314:9)
    at Object.next_token [as input] (D:\MakingSense\relay-webapp\src\node_modules\gulp-uglify\node_modules\uglify-js\lib\parse.js:562:9)
    at next (D:\MakingSense\relay-webapp\src\node_modules\gulp-uglify\node_modules\uglify-js\lib\parse.js:661:25)
    at subscripts (D:\MakingSense\relay-webapp\src\node_modules\gulp-uglify\node_modules\uglify-js\lib\parse.js:1337:13)
    at subscripts (D:\MakingSense\relay-webapp\src\node_modules\gulp-uglify\node_modules\uglify-js\lib\parse.js:1318:20)
    at expr_atom (D:\MakingSense\relay-webapp\src\node_modules\gulp-uglify\node_modules\uglify-js\lib\parse.js:1194:20)
    at maybe_unary (D:\MakingSense\relay-webapp\src\node_modules\gulp-uglify\node_modules\uglify-js\lib\parse.js:1358:19)
    at expr_ops (D:\MakingSense\relay-webapp\src\node_modules\gulp-uglify\node_modules\uglify-js\lib\parse.js:1393:24)
```