### PR TITLE
Improve Travis CI and add Docker scripts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,9 +21,6 @@ before_install:
   - sudo apt-get install -y libappindicator1 fonts-liberation
   - wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
   - sudo dpkg -i google-chrome*.deb
-before_script:
-  # Install dependencies
-  - yarn
 script:
   # Execute tests
   - gulp test

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,5 +22,7 @@ before_install:
   - wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
   - sudo dpkg -i google-chrome*.deb
 script:
+  # Execute build
+  - gulp build
   # Execute tests
   - gulp test

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,4 +26,4 @@ before_script:
   - yarn
 script:
   # Execute tests
-  - gulp test:travis
+  - gulp test

--- a/build-webapp.cmd
+++ b/build-webapp.cmd
@@ -6,5 +6,5 @@ CD src
 RD build /S /Q
 call yarn
 SET NODE_ENV=%1
-call gulp build
+call yarn run build
 CD %originalDir%

--- a/src/build-n-publish.sh
+++ b/src/build-n-publish.sh
@@ -1,0 +1,28 @@
+#!/bin/sh
+
+pkgName="relay-webapp"
+pkgVersion=${1:-"v0.0.0-build0"}
+cdnBaseUrl=${2:-"//cdn.fromdoppler.com/$pkgName"}
+cdnUrl="$cdnBaseUrl/$pkgVersion"
+
+# Exit immediately if a command exits with a non-zero status.
+set -e
+
+# Lines added to get the script running in the script path shell context
+# reference: http://www.ostricher.com/2014/10/the-right-way-to-get-the-directory-of-a-bash-script/
+cd $(dirname $0)
+
+./build-w-docker.sh $pkgVersion $cdnBaseUrl
+
+# Force pull the latest image version due to the cache not always is pruned immediately after an update is uploaded to docker hub
+docker pull dopplerrelay/doppler-relay-akamai-publish
+
+docker run --rm \
+    -e AKAMAI_CDN_HOSTNAME \
+    -e AKAMAI_CDN_USERNAME \
+    -e AKAMAI_CDN_PASSWORD \
+    -e AKAMAI_CDN_CPCODE \
+    -e "PROJECT_NAME=$pkgName" \
+    -e "VERSION_NAME=$pkgVersion" \
+    -v /`pwd`/build:/source \
+    dopplerrelay/doppler-relay-akamai-publish

--- a/src/build-w-docker.sh
+++ b/src/build-w-docker.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+
+pkgName="relay-webapp"
+pkgVersion=${1:-"v0.0.0-build0"}
+cdnBaseUrl=${2:-"//cdn.fromdoppler.com/$pkgName"}
+cdnUrl="$cdnBaseUrl/$pkgVersion"
+
+# Exit immediately if a command exits with a non-zero status.
+set -e
+
+# Lines added to get the script running in the script path shell context
+# reference: http://www.ostricher.com/2014/10/the-right-way-to-get-the-directory-of-a-bash-script/
+cd $(dirname $0)
+
+rm -rf `pwd`/build && mkdir `pwd`/build
+docker run --rm \
+    -v /`pwd`:/work \
+    -w /work \
+    node:6.10.1 \
+    /bin/sh -c "\
+        yarn global add gulp \
+        && yarn \
+        && gulp build \
+        && gulp test \
+    "

--- a/src/build-w-docker.sh
+++ b/src/build-w-docker.sh
@@ -21,5 +21,6 @@ docker run --rm \
         yarn global add gulp \
         && yarn \
         && gulp build \
-        && gulp test \
     "
+
+## I cannot run gulp test because it requires chrome

--- a/src/build-w-docker.sh
+++ b/src/build-w-docker.sh
@@ -20,7 +20,7 @@ docker run --rm \
     /bin/sh -c "\
         yarn global add gulp \
         && yarn \
-        && gulp build \
+        && yarn run build \
     "
 
 ## I cannot run gulp test because it requires chrome

--- a/src/gulpfile.js
+++ b/src/gulpfile.js
@@ -257,14 +257,14 @@ gulp.task('build-html', ['add-revision-numbers'], function () {
 
 gulp.task('build-mseditor', ['build-scripts-template-editor', 'add-revision-numbers'], function () {
   var sources = gulp.src([
-    paths.build + '/scripts/relay-editor.*.js'
+    paths.build + '/template-editor/relay-editor.*.js'
   ]);
   return gulp.src([
     paths.app + '/template-editor/index.html'
   ])
   .pipe(gulpInject(sources, {
     addRootSlash: false, // ensures proper relative paths removing the root slash
-    ignorePath: paths.build // ensures proper relative paths removing the absolute path
+    ignorePath: paths.build + '/template-editor' // ensures proper relative paths removing the absolute path
   }))
   .pipe(gulp.dest(paths.build + '/template-editor'));
 });
@@ -277,7 +277,7 @@ gulp.task('build-scripts-template-editor', function () {
   .pipe(uglify({
     mangle: false
   }))
-  .pipe(gulp.dest(paths.tmpPrebuild + '/scripts'));
+  .pipe(gulp.dest(paths.tmpPrebuild + '/template-editor'));
 });
 
 gulp.task('build-partials', function () {

--- a/src/gulpfile.js
+++ b/src/gulpfile.js
@@ -471,20 +471,3 @@ gulp.task('build', ['clean'], function () {
   );
 });
 
-/**
- * Task used for running the tests in travis
- */
-gulp.task('test:travis', function (done) {
-
-  gulp.start('default');
-
-  var argv = [getProtractorBinary(), 'protractor-travis-conf.js'].concat(process.argv.slice(3));
-
-  child_process
-    .spawn(getNodeBinary(), argv, { stdio: 'inherit' })
-    .on('error', function (e) { throw e; })
-    .on('close', function (e) { process.exit(e); });
-
-  gulp.start('test:unit');
-
-});

--- a/src/package.json
+++ b/src/package.json
@@ -47,7 +47,7 @@
     "selenium-webdriver": "~3.0.1"
   },
   "scripts": {
-    "postinstall": "bower install && webdriver-manager update",
+    "postinstall": "bower --allow-root install && webdriver-manager update",
     "start": "gulp"
   }
 }

--- a/src/package.json
+++ b/src/package.json
@@ -48,6 +48,7 @@
   },
   "scripts": {
     "postinstall": "bower --allow-root install && webdriver-manager update",
-    "start": "gulp"
+    "start": "gulp",
+    "build": "gulp build"
   }
 }

--- a/src/protractor-travis-conf.js
+++ b/src/protractor-travis-conf.js
@@ -1,5 +1,0 @@
-var configBuilder = require('./protractor-conf-builder');
-
-var config = configBuilder.getDefaults();
-
-exports.config = config;

--- a/src/run-w-docker.sh
+++ b/src/run-w-docker.sh
@@ -16,5 +16,5 @@ docker run --rm \
     /bin/sh -c "\
         yarn global add gulp \
         && yarn \
-        && gulp \
+        && yarn run start \
     "

--- a/src/run-w-docker.sh
+++ b/src/run-w-docker.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+
+# Exit immediately if a command exits with a non-zero status.
+set -e
+
+# Lines added to get the script running in the script path shell context
+# reference: http://www.ostricher.com/2014/10/the-right-way-to-get-the-directory-of-a-bash-script/
+cd $(dirname $0)
+
+docker run --rm \
+    -v /`pwd`:/work \
+    -p 3000:3000 \
+    -p 35729:35729 \
+    -w /work \
+    node:6.10.1 \
+    /bin/sh -c "\
+        yarn global add gulp \
+        && yarn \
+        && gulp \
+    "

--- a/src/wwwroot/template-editor/rev-manifest.json
+++ b/src/wwwroot/template-editor/rev-manifest.json
@@ -1,4 +1,0 @@
-{
-  "en.json": "en-b0629c2dde.json",
-  "es.json": "es-632cab0c57.json"
-}


### PR DESCRIPTION
Hi @mvillaseco and @cristiangiagante,

With this change, Travis CI will run the build, and in that way, we will detect if something goes wrong with the build process.

I have also added our docker scripts, to allow me (and you too) to run and build it without installing the dependencies. I added _build_n_publish_, I know that by the moment we are not publishing the WebApp to our CDN, but I think that we could do it soon (1 year? :P).

Finally, I applied some cleaning in Travis CI process.

Could you kindly review?

**UPDATE:** I have fixed some other issues:

* QA Deployment process was not working (for about a month!)
* Reference to template editor .js file was wrong