### PR TITLE
[DR-XXXX] Update bower version

### DIFF
--- a/src/package.json
+++ b/src/package.json
@@ -6,7 +6,7 @@
   "repository": "https://github.com/DopplerRelay/relay-webapp",
   "dependencies": {
     "body-parser": "~1.13.3",
-    "bower": "~1.4.1",
+    "bower": "^1.8.4",
     "express": "~4.13.3",
     "gulp-minify-css": "^1.2.0",
     "gulp-sass": "^2.0.4",


### PR DESCRIPTION
# Overview
 Update bower version because this lib deprecated all previous versions.