### PR TITLE
[DR-1692] Remove space in terms of use string at spanish language

### DIFF
--- a/src/wwwroot/locales/es-translation.js
+++ b/src/wwwroot/locales/es-translation.js
@@ -139,7 +139,7 @@ window['relay-translation-es'] = {
   "confirmation_domain": "Dominio:",
   "confirmation_domain_simple": "Dominio:",
   "confirmation_submit": "INGRESAR A MI CUENTA",
-  "confirmation_terms": "Acepto la <a target='_blank' href='https://www.dopplerrelay.com/privacidad'>Política de Privacidad</a>de Doppler.",
+  "confirmation_terms": "Acepto la <a target='_blank' href='https://www.dopplerrelay.com/privacidad'>Política de Privacidad</a> de Doppler.",
   "confirmation_promotions": "Quiero recibir promociones de Doppler y sus aliados.",
   "password": "Contraseña:",
   "password_simple": "Contraseña:",


### PR DESCRIPTION
## Background
  
We need to remove a missing space in a term of use string
  
## Changes done
  
- Remove space in spanish translation dictionary
  
## Pending to be done
  
N/A
  
## Notes
  
N/A
 
## Demo

![image](https://user-images.githubusercontent.com/7245667/42892381-124d819a-8a88-11e8-8973-9b63dea9a8f5.png)
 
![image](https://user-images.githubusercontent.com/7245667/42892369-0ade266c-8a88-11e8-90dc-47b94abf1cc2.png)
