### PR TITLE
[DR-1703] Use classic template editor for legacy templates in featured MSEditor accounts

### DIFF
--- a/src/spec/template_spec.js
+++ b/src/spec/template_spec.js
@@ -20,6 +20,15 @@ describe('Template Page', () => {
       }));
   }
 
+  function beginAuthenticatedSessionWithMSEditor() {
+    browser.addMockModule('descartableModule', () => angular
+      .module('descartableModule', [])
+      .run((jwtHelper, auth) => {
+        var permanentToken = 'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJuYmYiOjE0ODQ2MzAzMTgsImV4cCI6MTUzNDI1NjY1NCwiaWF0IjoxNDg0NjMwMzE4LCJpc3MiOiJodHRwOi8vbG9jYWxob3N0OjM0NzUxIiwic3ViIjoxMDAzLCJ1bmlxdWVfbmFtZSI6ImFtb3NjaGluaUBtYWtpbmdzZW5zZS5jb20iLCJyZWxheV9hY2NvdW50cyI6WyJhbW9zY2hpbmktbWFraW5nc2Vuc2UiXSwicmVsYXlfdG9rZW5fdmVyc2lvbiI6IjEuMC4wLWJldGE1IiwiZm9yY2VfbXNlZGl0b3IiOnRydWUsImp0aSI6IjdlMmQ0YTBhLTU4ZDItNDViYS04YjViLWIzM2U0ZGYxMWIxMSJ9.ftSOjsBuGEzO7F4qyx99fY0TGXFZrmfM7nBSiL2tLd0';
+        auth.loginByToken(permanentToken);
+      }));
+  }
+
   function setupTemplateResponse() {
     browser.addMockModule('descartableModule2', () => angular
       .module('descartableModule2', ['ngMockE2E'])
@@ -40,6 +49,72 @@ describe('Template Page', () => {
         $httpBackend.whenGET(/\/accounts\/[\d|-]*\/templates\/[\w|-]*\/body/).respond(200, {
           "name": "test",
           "html": "test",
+          "_links": []
+        });
+          
+        $httpBackend.whenGET(/\/accounts\/[\w|-]*\/status\/limits/).respond(200, {
+          "noLimits": true,
+          "dkimConfigurationRequired": false,
+          "domainConfigurationRequired": false,
+          "_links": []
+        });
+      }
+    ));
+  }
+
+  function setupTemplateResponseWithMSEditor() {
+    browser.addMockModule('descartableModule2', () => angular
+      .module('descartableModule2', ['ngMockE2E'])
+      .run($httpBackend => {
+        $httpBackend.whenGET(/\/accounts\/[\d|-]*\/templates\/[\w|-]*/).respond(200, {
+          "from_name": "test",
+          "from_email": "test@test.test",
+          "subject": "test subject",
+          "body": "test body",
+          "name": "test name",
+          "id": "32e93fa4-c8f4-467a-a2bb-da95f72a27b4",
+          "last_updated": "2018-07-12T13:28:23Z",
+          "created_at": "2018-07-12T13:27:40Z",
+          "bodyType": "mseditor",
+          "_links": []
+        });
+
+        $httpBackend.whenGET(/\/accounts\/[\d|-]*\/templates\/[\w|-]*\/body/).respond(200, {
+          "name": "test",
+          "html": "test",
+          "_links": []
+        });
+          
+        $httpBackend.whenGET(/\/accounts\/[\w|-]*\/status\/limits/).respond(200, {
+          "noLimits": true,
+          "dkimConfigurationRequired": false,
+          "domainConfigurationRequired": false,
+          "_links": []
+        });
+      }
+    ));
+  }
+
+  function setupEmptyTemplateResponse() {
+    browser.addMockModule('descartableModule2', () => angular
+      .module('descartableModule2', ['ngMockE2E'])
+      .run($httpBackend => {
+        $httpBackend.whenGET(/\/accounts\/[\d|-]*\/templates\/[\w|-]*/).respond(200, {
+          "from_name": "test",
+          "from_email": "test@test.test",
+          "subject": "test subject",
+          "body": "test body",
+          "name": "test name",
+          "id": "32e93fa4-c8f4-467a-a2bb-da95f72a27b4",
+          "last_updated": "2018-07-12T13:28:23Z",
+          "created_at": "2018-07-12T13:27:40Z",
+          "bodyType": "empty",
+          "_links": []
+        });
+
+        $httpBackend.whenGET(/\/accounts\/[\d|-]*\/templates\/[\w|-]*\/body/).respond(200, {
+          "name": "test",
+          "html": "",
           "_links": []
         });
           
@@ -336,7 +411,7 @@ describe('Template Page', () => {
     expect(templatePage.getTotalInvalidFields()).toBe(expectedTotalInvalidFields);
   });
 
-  it('should not show the mseditor button when the token forceMseditor is null', () => {
+  it('should not show the mseditor button in template creation when the token forceMseditor is null', () => {
     // Arrange
     beginAuthenticatedSession();
     var templatePage = new TemplatePage();
@@ -349,7 +424,7 @@ describe('Template Page', () => {
     expect(templatePage.isTemplateMsEditorInputDisplayed()).toBe(false);
   });
 
-  it('should show the mseditor button when the token forceMseditor is true', () => {
+  it('should show the mseditor button in template creation when the token forceMseditor is true', () => {
     // Arrange
     browser.addMockModule('descartableModule', () => angular
       .module('descartableModule', [])
@@ -365,5 +440,70 @@ describe('Template Page', () => {
     // Assert
     expect(templatePage.isTemplateHtmlRawInputDisplayed()).toBe(false);
     expect(templatePage.isTemplateMsEditorInputDisplayed()).toBe(true);
+  });
+
+  it('should show mseditor button in template edition when template was created with mseditor', () => {
+    // Arrange
+    beginAuthenticatedSessionWithMSEditor();
+    setupTemplateResponseWithMSEditor();
+    var templatePage = new TemplatePage();
+
+    // Act
+    browser.get('/#/templates/32e93fa4-c8f4-467a-a2bb-da95f72a27b4');
+
+    // Assert
+    expect(templatePage.isTemplateMsEditorInputDisplayed()).toBe(true);
+  });
+
+  it('should show mseditor button in template edition when template is empty and account is mseditor featured', () => {
+    // Arrange
+    beginAuthenticatedSessionWithMSEditor();
+    setupEmptyTemplateResponse();
+    var templatePage = new TemplatePage();
+
+    // Act
+    browser.get('/#/templates/32e93fa4-c8f4-467a-a2bb-da95f72a27b4');
+
+    // Assert
+    expect(templatePage.isTemplateMsEditorInputDisplayed()).toBe(true);
+  });
+
+  it('should not show mseditor button in template edition when template is empty and account is not mseditor featured', () => {
+    // Arrange
+    beginAuthenticatedSession();
+    setupEmptyTemplateResponse();
+    var templatePage = new TemplatePage();
+
+    // Act
+    browser.get('/#/templates/32e93fa4-c8f4-467a-a2bb-da95f72a27b4');
+
+    // Assert
+    expect(templatePage.isTemplateMsEditorInputDisplayed()).toBe(false);
+  });
+
+  it('should not show mseditor button in template edition when template is rawHtml in not featured account with mseditor', () => {
+    // Arrange
+    beginAuthenticatedSession();
+    setupTemplateResponse();
+    var templatePage = new TemplatePage();
+
+    // Act
+    browser.get('/#/templates/32e93fa4-c8f4-467a-a2bb-da95f72a27b4');
+
+    // Assert
+    expect(templatePage.isTemplateMsEditorInputDisplayed()).toBe(false);
+  });
+
+  it('should not show mseditor button in template edition when template is rawHtml in a featured account with mseditor', () => {
+    // Arrange
+    beginAuthenticatedSessionWithMSEditor();
+    setupTemplateResponse();
+    var templatePage = new TemplatePage();
+
+    // Act
+    browser.get('/#/templates/32e93fa4-c8f4-467a-a2bb-da95f72a27b4');
+
+    // Assert
+    expect(templatePage.isTemplateMsEditorInputDisplayed()).toBe(false);
   });
 });

--- a/src/wwwroot/partials/templates/template.html
+++ b/src/wwwroot/partials/templates/template.html
@@ -2,7 +2,7 @@
   <!-- Asking server for data -->
   <spinner class="spinner padded" ng-show="loadInProgress"></spinner>
 </div>
-<form novalidate name="form" ng-show="!loadInProgress" ng-submit="saveHtmlRaw()" ng-class="submitted ? 'ng-submitted' : ''">
+<form novalidate name="form" ng-show="!loadInProgress" ng-submit="saveTemplate()" ng-class="submitted ? 'ng-submitted' : ''">
   <section class="templates--information">
     <div class="section--wrapper">
       <h2>{{'templates_information_title' | translate}}</h2>
@@ -55,15 +55,15 @@
       <div class="flex flex--between">
         <label for="uContent">{{'templates_edition_subtitle' | translate}}</label>
       </div>    
-      <div class="templates-htmlraw--container" ng-show="{{!forceMsEditor}}">  
+      <div class="templates-htmlraw--container" ng-show="isHtmlTemplate">  
         <textarea id="uContent"
                   name="uContent"
                   validation-errors
-                  ng-required="{{!forceMsEditor}}"
+                  ng-required="isHtmlTemplate"
                   ng-model="template.content"
                   class="input width--full"></textarea>
       </div>
-      <div class="grid templates-selector--container" ng-show="{{forceMsEditor}}">
+      <div class="grid templates-selector--container" ng-show="!isHtmlTemplate">
         <div class="templates-mseditor--container">
           <label>{{ 'templates_edition_mseditor_label' | translate }}</label> 
           <a class="button-mseditor--selector" ng-click="saveAndEditWithMseditor();">
@@ -90,6 +90,7 @@
       <div class="section--wrapper text--center">
         <input type="submit"
               class="button button--medium"
+              
               ng-class="!saveInProgress ? '' : 'button--disabled'"
               ng-disabled="saveInProgress"
               value="{{'templates_save_button' | translate}}" />

--- a/src/wwwroot/services/templates.js
+++ b/src/wwwroot/services/templates.js
@@ -17,8 +17,11 @@
 
     var templatesService = {
       getAllData: getAllData,
-      getTemplateWithBody: getTemplateWithBody,
-      save: save,
+      getTemplate: getTemplate,
+      getTemplateBody: getTemplateBody,
+      createTemplate: createTemplate,
+      editTemplate: editTemplate,
+      editTemplateBody: editTemplateBody,
       deleteTemplate: deleteTemplate,
     };
 
@@ -65,36 +68,8 @@
       }).then(extractData);
     }
 
-    function getTemplateWithBody(templateId) {
-      return getTemplate(templateId).then(function (template) {
-        return getTemplateBody(templateId).then(function (body) {
-          return {
-            from_name: template.from_name,
-            from_email: template.from_email,
-            subject: template.subject,
-            id: template.id,
-            name: body.name,
-            body: body.html
-          };
-        });
-      });
-    }
-
-    function save(templateModel) {
+    function createTemplate(templateModel) {
       var accountId = auth.getAccountId();
-      var isCreating = !templateModel.id;
-      var updateTemplatePromise = isCreating ? createTemplate(accountId, templateModel) : editTemplate(accountId, templateModel);
-      return updateTemplatePromise.then(function (templateId) {
-        return editTemplateBody(accountId, templateId, templateModel.name, templateModel.body).then(function () {
-          return templateId;
-        }).catch(function (reason) {
-          // TODO: Show a special message error when template was update but body fails
-          return $q.reject(reason);
-        });
-      });
-    }
-
-    function createTemplate(accountId, templateModel) {
       return $http({
         actionDescription: 'action_templates_creating',
         method: 'POST',
@@ -110,7 +85,8 @@
       });
     }
 
-    function editTemplate(accountId, templateModel) {
+    function editTemplate(templateModel) {
+      var accountId = auth.getAccountId();
       return $http({
         // TODO: check action description
         actionDescription: 'Editing a template',
@@ -128,7 +104,8 @@
       });
     }
 
-    function editTemplateBody(accountId, templateId, name, body) {
+    function editTemplateBody(templateId, name, body) {
+      var accountId = auth.getAccountId();
       return $http({
         actionDescription: 'Editing a template body',
         method: 'PUT',


### PR DESCRIPTION
## Background
  
We need to use classic template editor in legacy templates for accounts with MSEditor feature enabled.
We need to be able to save MSEditor template content
  
## Changes done
  
Update Template controller and related partial view to handle Legacy templates

Update Template service to save MSEditor templates and handle legacy templates

Tests added
  
## Pending to be done
  
N/A
  
## Notes
  
Now, when a MSEditor template type is open to edit is not being called anymore the GET /.../templates/{id}/body WEB API call.