### PR TITLE
[DR-1738] Cancellation blocks upgrades

### DIFF
--- a/src/spec/page-objects/new-plan.js
+++ b/src/spec/page-objects/new-plan.js
@@ -20,7 +20,6 @@ class MyPlanPage {
               {
                 "noLimits": true,
                 "dkimConfigurationRequired": true,
-                "endDate": "2018-04-25T13:03:16Z",
                 "domainConfigurationRequired": true,
                 "hasNotDeliveries": true
               });

--- a/src/spec/settings_spec.js
+++ b/src/spec/settings_spec.js
@@ -34,7 +34,6 @@ describe('Settings Page', () => {
         {
           "noLimits": true,
           "dkimConfigurationRequired": true,
-          "endDate": "3018-04-25T13:03:16Z",
           "domainConfigurationRequired": true,
           "hasNotDeliveries": true
         });

--- a/src/wwwroot/controllers/MainCtrl.js
+++ b/src/wwwroot/controllers/MainCtrl.js
@@ -57,7 +57,9 @@
 
   function updateLimitsAndTrialData(limits) {
     $rootScope.accountLimits = limits;
-    var freeTrialEndDate = limits.endDate;
+    // TODO: now, cancellation date is not considered anymore like trial end date,
+    // we could show a different message for cancellation.
+    var freeTrialEndDate = limits.trialEndDate;
     if (!freeTrialEndDate) {
       $rootScope.freeTrialStatus = null;
       return;

--- a/src/wwwroot/controllers/PlanCtrl.js
+++ b/src/wwwroot/controllers/PlanCtrl.js
@@ -78,6 +78,7 @@
             vm.isTrialEnded = result.data.accountClosed && !result.data.cancellationDate;
             vm.trialEndDate = result.data.trialEndDate;
             vm.cancellationDate = result.data.cancellationDate;
+            vm.hasCancellationDate = !!result.data.cancellationDate;
             vm.resetDate = result.data.endDate;
             vm.currentMonthlyCount = result.data.deliveriesCount;
             vm.planStatusInfoLoader = false;
@@ -181,7 +182,7 @@
     }
 
     function isValidUpgradeablePlan() {
-      return !requiresDomainConfiguration() && !requiresDeliveries();
+      return !requiresDomainConfiguration() && !requiresDeliveries() && !vm.hasCancellationDate;
     }
   
     function requiresDomainConfiguration() {

--- a/src/wwwroot/controllers/PlanCtrl.js
+++ b/src/wwwroot/controllers/PlanCtrl.js
@@ -44,6 +44,7 @@
         vm.currentPlanEmailsAmount = response.data.includedDeliveries;
         vm.currentPlanEmailPrice = response.data.extraDeliveryCost;
         vm.currency = response.data.currency;
+        // TODO: improve it splitting free trial and free accounts behavior
         vm.isFreeTrial = response.data.fee && response.data.includedDeliveries ? false : true;
         vm.currentIpsPlanCount = response.data.ips_count || 0;
         vm.hasScheduledPlan = !response.data.endDate;
@@ -72,8 +73,11 @@
       return settings.getStatusPlanInfo()
           .then(function (result) {
             vm.extraEmailsSent = 0;
-            vm.isAccountClosed = result.data.accountClosed;
-            vm.accountEndDate = result.data.accountEndDate;
+            // TODO: consider prepare these two values isAccountCanceled and isTrialEnded in backend in place of accountClosed
+            vm.isAccountCanceled = result.data.accountClosed && result.data.cancellationDate; 
+            vm.isTrialEnded = result.data.accountClosed && !result.data.cancellationDate;
+            vm.trialEndDate = result.data.trialEndDate;
+            vm.cancellationDate = result.data.cancellationDate;
             vm.resetDate = result.data.endDate;
             vm.currentMonthlyCount = result.data.deliveriesCount;
             vm.planStatusInfoLoader = false;

--- a/src/wwwroot/locales/en-translation.js
+++ b/src/wwwroot/locales/en-translation.js
@@ -465,6 +465,7 @@
   "tracking_domain_description": "Add a CNAME value into the DNS records of your domain in order to start using your account.",
   "tracking_domain_description_link": "Learn how to do it here.",
   "tracking_config_help_href": "en/how-to-configure-the-subdomain-tracking",
+  "validation_canceled_account": "Change plan is not possible because account has a cancellation date.",
   "validation_requirements_title": "Before buying a {{ companyName }} plan it is necessary to complete the following steps:",
   "validation_step_one": "Verify your domain by configuring your DKIM, SPF and tracking subdomain.",
   "validation_step_one_link": "Find all the information here.",

--- a/src/wwwroot/locales/es-translation.js
+++ b/src/wwwroot/locales/es-translation.js
@@ -479,6 +479,7 @@ window['relay-translation-es'] = {
   "tracking_domain_description": "Añade un registro CNAME en los registros DNS de tu dominio para poder comenzar a utilizar tu cuenta.",
   "tracking_domain_description_link": "Aprende cómo hacerlo aquí.",
   "tracking_config_help_href": "es/configuracion-subdominio-seguimiento",
+  "validation_canceled_account": "No es posible cambiar de plan porque la cuenta tiene fecha de cancelación.",
   "validation_requirements_title": "Antes de contratar un plan de {{ companyName }} es necesario completar los siguientes pasos:",
   "validation_step_one": "Verifica tu dominio, para eso es necesario configurar tu DKIM, SPF y Subdominio de Seguimiento.",
   "validation_step_one_link": "Encuentra toda la información aquí.",

--- a/src/wwwroot/partials/header.html
+++ b/src/wwwroot/partials/header.html
@@ -3,10 +3,10 @@
   <div class="flex flex--center">
     <p>
       <strong>        
-        <span ng-show="freeTrialStatus.isFreeTrialEnded && !accountLimits.requiresDomainConfiguration">{{'free_trial_header_ended_text' | translate}}</span>
-        <span ng-show="freeTrialStatus.isFreeTrialAlmostEnded && !accountLimits.requiresDomainConfiguration">{{'free_trial_header_almost_ended_text' | translate:{trialDaysLeft:freeTrialStatus.trialDaysLeft} }}</span>
-        <span ng-show="freeTrialStatus.isFreeTrialEndToday && !accountLimits.requiresDomainConfiguration">{{'free_trial_header_end_today_text' | translate}}</span>
-        <span ng-show="!freeTrialStatus.isFreeTrialEnded && !freeTrialStatus.isFreeTrialAlmostEnded && !freeTrialStatus.isFreeTrialEndToday && !accountLimits.requiresDomainConfiguration">{{'free_trial_header_trial_text' | translate}}</span>
+        <span ng-show="freeTrialStatus && freeTrialStatus.isFreeTrialEnded && !accountLimits.requiresDomainConfiguration">{{'free_trial_header_ended_text' | translate}}</span>
+        <span ng-show="freeTrialStatus && freeTrialStatus.isFreeTrialAlmostEnded && !accountLimits.requiresDomainConfiguration">{{'free_trial_header_almost_ended_text' | translate:{trialDaysLeft:freeTrialStatus.trialDaysLeft} }}</span>
+        <span ng-show="freeTrialStatus && freeTrialStatus.isFreeTrialEndToday && !accountLimits.requiresDomainConfiguration">{{'free_trial_header_end_today_text' | translate}}</span>
+        <span ng-show="freeTrialStatus && !freeTrialStatus.isFreeTrialEnded && !freeTrialStatus.isFreeTrialAlmostEnded && !freeTrialStatus.isFreeTrialEndToday && !accountLimits.requiresDomainConfiguration">{{'free_trial_header_trial_text' | translate}}</span>
         <span ng-show="accountLimits.requiresDomainConfiguration">{{'domain_not_ready_header_text' | translate}}</span>
       </strong>
     </p>

--- a/src/wwwroot/partials/settings/my-plan.html
+++ b/src/wwwroot/partials/settings/my-plan.html
@@ -4,8 +4,8 @@
       {{ 'plans_text' | translate }}
     </h2>
     <p>{{ 'my_plan_subtitle' | translate }}</p>
-    <label class="color--orange" ng-if="vm.isAccountClosed && vm.isFreeTrial">{{ 'my_plan_free_trial_closed' | translate }}</label>
-    <label class="color--orange" ng-if="vm.isAccountClosed && !vm.isFreeTrial">{{ 'my_plan_account_closed' | translate }}</label>
+    <label class="color--orange" ng-if="vm.isTrialEnded">{{ 'my_plan_free_trial_closed' | translate }}</label>
+    <label class="color--orange" ng-if="vm.isAccountCanceled">{{ 'my_plan_account_closed' | translate }}</label>
   </div>
   <div class="section--wrapper my-plan--info-container">
     <div class="item flex flex--wrap first">
@@ -42,11 +42,18 @@
         <spinner class="spinner" ng-class="vm.planStatusInfoLoader ?  'show':'hide'"></spinner>
       </div>
       <div class="flex two flex--wrap">
-        <label class="width--full special uppercase" ng-if="vm.accountEndDate && vm.isFreeTrial">{{ 'my_plan_free_trial_end_label' | translate }}</label>
-        <label class="width--full special uppercase" ng-if="vm.accountEndDate && !vm.isFreeTrial">{{ 'my_plan_account_end_label' | translate }}</label>
-        <label class="width--full special uppercase" ng-if="!vm.accountEndDate">{{ 'my_plan_renewal_date' | translate }}</label>
-        <p class="renewal-date" ng-if="vm.accountEndDate">{{ vm.accountEndDate | date :'mediumDate' :'+0' }}</p>        
-        <p class="renewal-date" ng-if="!vm.accountEndDate">{{ vm.resetDate | date :'mediumDate' :'+0' }}</p>
+        <div ng-if="vm.trialEndDate">
+          <label class="width--full special uppercase">{{ 'my_plan_free_trial_end_label' | translate }}</label>
+          <p class="renewal-date">{{ vm.trialEndDate | date :'mediumDate' :'+0' }}</p>        
+        </div>
+        <div ng-if="vm.cancellationDate">
+          <label class="width--full special uppercase">{{ 'my_plan_account_end_label' | translate }}</label>
+          <p class="renewal-date">{{ vm.cancellationDate | date :'mediumDate' :'+0' }}</p>        
+        </div>
+        <div ng-if="!vm.trialEndDate && !vm.cancellationDate">
+          <label class="width--full special uppercase">{{ 'my_plan_renewal_date' | translate }}</label>
+          <p class="renewal-date">{{ vm.resetDate | date :'mediumDate' :'+0' }}</p>
+        </div>
         <spinner class="spinner" ng-class="vm.planStatusInfoLoader ?  'show':'hide'"></spinner>
       </div>
     </div>

--- a/src/wwwroot/partials/settings/my-plan.html
+++ b/src/wwwroot/partials/settings/my-plan.html
@@ -160,7 +160,7 @@
         <span class="input--error" ng-show="vm.errorPlanUpgrade"><i class="arrow--up"></i>{{'my_plan_pricing_chart_button_validation' | translate}}</span>
         <span class="input--error" ng-show="vm.errorPlanUpgrade"><i class="arrow--up"></i>{{'my_plan_pricing_chart_button_validation' | translate}}</span>
       </div>
-      <div ng-show="!vm.isValidUpgradeablePlan()" class="arrow--box-up">
+      <div ng-show="!vm.isValidUpgradeablePlan() && !vm.hasCancellationDate" class="arrow--box-up">
         <h5>{{'validation_requirements_title' | translate:{companyName:companyName} }}</h5>
         <ol>
           <li ng-show="vm.requiresDomainConfiguration()" class="step not-ready">
@@ -173,6 +173,9 @@
             <span>{{'validation_step_two' | translate}} <a class="arrow--box-link" href="{{'validation_step_two_href' | translate}}">{{'validation_step_two_link' | translate}}</a></span>
           </li>
         </ol>
+      </div>
+      <div ng-show="vm.hasCancellationDate" class="arrow--box-up">
+        <h5>{{'validation_canceled_account' | translate:{companyName:companyName} }}</h5>
       </div>
     </div>
     <hr class="default"/>

--- a/src/wwwroot/services/auth.js
+++ b/src/wwwroot/services/auth.js
@@ -301,7 +301,8 @@
           daily: mapLimit(response.data.daily),
           hourly: mapLimit(response.data.hourly),
           hasLimits: !response.data.noLimits,
-          endDate: mapDate(response.data.endDate),
+          trialEndDate: mapDate(response.data.trialEndDate),
+          cancellationDate: mapDate(response.data.cancellationDate),
           requiresDomainConfiguration: !!response.data.domainConfigurationRequired,
           requiresDeliveries: !!response.data.hasNotDeliveries
         };


### PR DESCRIPTION
Hi team, 

The main behavior improvement of these changes is not allowing do upgrades or downgrades if the account has a cancellation date.

Additionally, it also makes our code more explicit about the semantic differences between trial end and canceled accounts.

Could you review? (I will not merge it during this sprint, I prefer adding some tests in the next one)