### PR TITLE
[DM-52] Add preview templates

### DIFF
--- a/src/karma.conf.js
+++ b/src/karma.conf.js
@@ -114,7 +114,7 @@ module.exports = function (config) {
 
     // start these browsers
     // available browser launchers: https://npmjs.org/browse/keyword/karma-launcher
-
+    browserNoActivityTimeout: 80000,
     browsers: [
       // 'PhantomJS', // It does not work yet, see https://github.com/ariya/phantomjs/issues/14506#issuecomment-251611067
       'Chrome'

--- a/src/spec/billing_spec.js
+++ b/src/spec/billing_spec.js
@@ -317,7 +317,7 @@ describe('Billing Page', () => {
     var country = 'Bolivia, Plurinational State Of';
     var cardHolder = 'TestName TestLastName';
     var creditCardNumber = '4485929253917658';
-    var expDate = '0919';
+    var expDate = '0999';
     var secCode = '123'
 
     // Act
@@ -343,7 +343,7 @@ describe('Billing Page', () => {
     expect(billingPage.isCountryDisplayed()).toContain(country);
     expect(billingPage.isCardHolderDisplayed()).toBe(cardHolder);
     expect(billingPage.isCcNumberDisplayed()).toBe('************7658');
-    expect(billingPage.isExpDateDisplayed()).toBe('09/19');
+    expect(billingPage.isExpDateDisplayed()).toBe('09/99');
     expect(billingPage.isSecCodeDisplayed()).toBe('***');
     expect(billingPage.isBillingPageDisplayed()).toBeFalsy();
 
@@ -367,7 +367,7 @@ describe('Billing Page', () => {
     var country = 'Bolivia, Plurinational State Of';
     var cardHolder = 'TestName TestLastName';
     var creditCardNumber = '4485929253917658';
-    var expDate = '0919';
+    var expDate = '0999';
     var secCode = '123'
 
     // Act
@@ -408,7 +408,7 @@ describe('Billing Page', () => {
     var country = 'Bolivia, Plurinational State Of';
     var cardHolder = 'TestName TestLastName';
     var creditCardNumber = '4485929253917658';
-    var expDate = '0919';
+    var expDate = '0999';
     var secCode = '123'
 
     billingPage.setName(name);
@@ -453,7 +453,7 @@ describe('Billing Page', () => {
     var country = 'Bolivia, Plurinational State Of';
     var cardHolder = 'TestName TestLastName';
     var creditCardNumber = '4444444444444444';
-    var expDate = '0919';
+    var expDate = '0999';
     var secCode = '123'
 
     billingPage.setName(name);
@@ -502,7 +502,7 @@ describe('Billing Page', () => {
     var country = 'Bolivia, Plurinational State Of';
     var cardHolder = 'TestName TestLastName';
     var creditCardNumber = '4485929253917658';
-    var expDate = '0919';
+    var expDate = '0999';
     var secCode = '123'
 
     // Act

--- a/src/wwwroot/controllers/TemplateCtrl.js
+++ b/src/wwwroot/controllers/TemplateCtrl.js
@@ -10,10 +10,11 @@
     'templates',
     '$routeParams',
     '$location',
-    '$rootScope'
+    '$rootScope',
+    '$sce'
   ];
 
-  function TemplateCtrl($scope, templates, $routeParams, $location, $rootScope) {
+  function TemplateCtrl($scope, templates, $routeParams, $location, $rootScope, $sce) {
 
     $scope.template = {
       id: "",
@@ -27,9 +28,13 @@
     $scope.loadInProgress = false;
     $scope.saveInProgress = false;
     $scope.isHtmlTemplate = true;
-
+    $scope.htmlPreviewContent = "";
     $scope.saveTemplate = saveTemplate;
     $scope.saveAndEditWithMseditor = saveAndEditWithMseditor;
+
+    $scope.$watch("template.content", function(htmlContent) {
+      $scope.htmlPreviewContent = $sce.trustAsHtml(htmlContent);
+    }, true);
 
     if ($routeParams["templateId"]) {
       load($routeParams["templateId"]);

--- a/src/wwwroot/controllers/TemplatesCtrl.js
+++ b/src/wwwroot/controllers/TemplatesCtrl.js
@@ -19,6 +19,7 @@
     $scope.deleteDialogs = new Array();
     $scope.toggleDeleteDialog = toggleDeleteDialog;
     $scope.hideDeleteDialog = hideDeleteDialog;
+    $scope.previewTemplate = previewTemplate;
 
     initialize();
 
@@ -48,6 +49,10 @@
         })
         .finally(function () {
         });
+    }
+
+    function previewTemplate(thumbnailUrl) {
+      window.open(thumbnailUrl);
     }
 
     function getItems() {

--- a/src/wwwroot/images/svg/preview.svg
+++ b/src/wwwroot/images/svg/preview.svg
@@ -1,0 +1,16 @@
+<svg width="32" height="32" 
+    xmlns="http://www.w3.org/2000/svg">
+
+    <g>
+        <title>PreviewIcon</title>
+        <rect fill="none" id="canvas_background" height="402" width="582" y="-1" x="-1"/>
+    </g>
+    <g>
+        <title>Layer 1</title>
+        <polyline id="svg_2" stroke-width="2" stroke-miterlimit="10" stroke-linejoin="round" stroke-linecap="round" stroke="#FFFFFF" points="   649,137.999 675,137.999 675,155.999 661,155.999  " fill="none"/>
+        <polyline id="svg_3" stroke-width="2" stroke-miterlimit="10" stroke-linejoin="round" stroke-linecap="round" stroke="#FFFFFF" points="   653,155.999 649,155.999 649,141.999  " fill="none"/>
+        <polyline id="svg_4" stroke-width="2" stroke-miterlimit="10" stroke-linejoin="round" stroke-linecap="round" stroke="#FFFFFF" points="   661,156 653,162 653,156  " fill="none"/>
+        <path fill="#e78224" id="svg_7" d="m16,25c-4.265,0 -8.301,-1.807 -11.367,-5.088c-0.377,-0.403 -0.355,-1.036 0.048,-1.413c0.404,-0.377 1.036,-0.355 1.414,0.048c2.683,2.872 6.2,4.453 9.905,4.453c4.763,0 9.149,-2.605 11.84,-7c-2.69,-4.395 -7.077,-7 -11.84,-7c-4.938,0 -9.472,2.801 -12.13,7.493c-0.272,0.481 -0.884,0.651 -1.363,0.377c-0.481,-0.272 -0.649,-0.882 -0.377,-1.363c3.017,-5.327 8.203,-8.507 13.87,-8.507c5.668,0 10.853,3.18 13.87,8.507c0.173,0.306 0.173,0.68 0,0.985c-3.017,5.327 -8.202,8.508 -13.87,8.508z"/>
+        <path fill="#e78224" id="svg_9" d="m16,21c-2.757,0 -5,-2.243 -5,-5s2.243,-5 5,-5s5,2.243 5,5s-2.243,5 -5,5zm0,-8c-1.654,0 -3,1.346 -3,3s1.346,3 3,3s3,-1.346 3,-3s-1.346,-3 -3,-3z"/>
+    </g>
+</svg>

--- a/src/wwwroot/locales/en-translation.js
+++ b/src/wwwroot/locales/en-translation.js
@@ -107,6 +107,8 @@
   "templates_edition_html_example_3": "<head>",
   "templates_edition_html_example_4": "<meta http-equiv='Content-Type' content='text/html;",
   "templates_edition_preview": "Preview",
+  "templates_edition_preview_title": "Preview",
+  "templates_edition_preview_subtitle": "Here you can view your template in real time",
   "templates_publish_button": "Publish Template",
   "templates_draft_button": "Save as draft",
   "templates_save_button": "Save Template",

--- a/src/wwwroot/locales/es-translation.js
+++ b/src/wwwroot/locales/es-translation.js
@@ -119,6 +119,8 @@ window['relay-translation-es'] = {
   "templates_edition_html_example_3": "<head>",
   "templates_edition_html_example_4": "<meta http-equiv='Content-Type' content='text/html;",
   "templates_edition_preview": "Previsualizar",
+  "templates_edition_preview_title": "Vista previa",
+  "templates_edition_preview_subtitle": "Aquí puedes visualizar tu plantilla en tiempo real",
   "templates_publish_button": "Publicar Plantilla",
   "templates_draft_button": "Guardar como borrador",
   "templates_save_button": "Guardar Plantilla",

--- a/src/wwwroot/partials/templates/template.html
+++ b/src/wwwroot/partials/templates/template.html
@@ -54,7 +54,7 @@
       <h2>{{'templates_edition_title' | translate}}</h2>
       <div class="flex flex--between">
         <label for="uContent">{{'templates_edition_subtitle' | translate}}</label>
-      </div>    
+      </div>
       <div class="templates-htmlraw--container" ng-show="isHtmlTemplate">  
         <textarea id="uContent"
                   name="uContent"
@@ -89,19 +89,22 @@
       </div>
       <div class="section--wrapper text--center">
         <input type="submit"
-              class="button button--medium"
-              
+              class="button button--medium button--left"
               ng-class="!saveInProgress ? '' : 'button--disabled'"
               ng-disabled="saveInProgress"
               value="{{'templates_save_button' | translate}}" />
       </div>
-      <div class="section--wrapper text--center">
-        <input type="button"
-              class="button button--medium"
-              
-              ng-class="!previewInProgress ? '' : 'button--disabled'"
-              ng-disabled="previewInProgress"
-              value="{{'templates_preview_button' | translate}}" />
+    </div>
+  </section>
+  <section class="templates--information" ng-show="isHtmlTemplate">
+    <div class="section--wrapper">
+      <h2>{{'templates_edition_preview_title' | translate}}</h2>
+      <div class="flex flex--between subtittle">
+        <label for="contentPreview">{{'templates_edition_preview_subtitle' | translate}}</label>
+      </div>
+      <hr>
+      <div class="templates-htmlraw--container">
+          <div id="contentPreview" ng-bind-html='htmlPreviewContent'></div>
       </div>
     </div>
   </section>

--- a/src/wwwroot/partials/templates/template.html
+++ b/src/wwwroot/partials/templates/template.html
@@ -95,6 +95,14 @@
               ng-disabled="saveInProgress"
               value="{{'templates_save_button' | translate}}" />
       </div>
+      <div class="section--wrapper text--center">
+        <input type="button"
+              class="button button--medium"
+              
+              ng-class="!previewInProgress ? '' : 'button--disabled'"
+              ng-disabled="previewInProgress"
+              value="{{'templates_preview_button' | translate}}" />
+      </div>
     </div>
   </section>
 </form>

--- a/src/wwwroot/partials/templates/templates.html
+++ b/src/wwwroot/partials/templates/templates.html
@@ -48,6 +48,7 @@
                   <div>
                     <!--<svg class="icon m-glass"><use xlink:href="/images/sprite.svg#doppler-icon-descargar-01"></use></svg>
                     <svg class="icon m-glass"><use xlink:href="/images/sprite.svg#doppler-icon-subir-01"></use></svg>-->
+                    <svg class="icon m-glass" ng-click="previewTemplate(template.thumbnail)"><use xlink:href="/images/sprite.svg#doppler-icon-preview"></use></svg>
                   </div>
                   <div>
                     <svg class="icon m-glass" ng-show="!deleteDialogs[template.id]" ng-click="toggleDeleteDialog(template.id)"><use xlink:href="/images/sprite.svg#doppler-icon-borrar-01"></use></svg>

--- a/src/wwwroot/styles/views/_templates.scss
+++ b/src/wwwroot/styles/views/_templates.scss
@@ -91,7 +91,7 @@
       @include col(1/3, $cycle:3);
       padding: 0 !important;
       transition:all linear 0.5s;
-      img{height: 180px; width: 100%;object-fit: cover;object-position: left;}
+      img{height: 180px; width: 100%;object-fit: contain;}
       div.content--box{
         border-top: $suit-border-default;
         padding: toem(16px);

--- a/src/wwwroot/styles/views/_templates.scss
+++ b/src/wwwroot/styles/views/_templates.scss
@@ -44,6 +44,7 @@
    &:first-of-type{ margin-right: 3%;}
    &:last-of-type{ margin-left: 3%;}
   }
+  .subtittle{align-items: center;}
   h4{margin:torem(30px) 0 0 0;}
 }
 .templates--custom{


### PR DESCRIPTION
Hi team!

Here I added 2 features:
- In the list of templates, I added one button to view in another window, the generated image.
![image](https://user-images.githubusercontent.com/9144465/65632961-5a60a780-dfb1-11e9-8141-61583a077ddc.png)

- And when you create or edit a template, at the bottom you can see in real-time the rendered HTML, which is taken from the template content.
![screencapture-dopplerrelayqa-makingsense-2019-09-25-16_27_56](https://user-images.githubusercontent.com/9144465/65633020-7ebc8400-dfb1-11e9-8afc-129166f5db42.png)

If someone wants to try it, you can go to this URL: [Relay QA](https://dopplerrelayqa.makingsense.com/)
And log in with username1@dopplerrelay.com and password1

If anyone has suggestions, please comment!