### PR TITLE
[DE-30] Html broken template editor. Added  file server setting

### DIFF
--- a/src/wwwroot/template-editor/adapterService.js
+++ b/src/wwwroot/template-editor/adapterService.js
@@ -493,7 +493,8 @@
         sharedSocialNetworks: [],
         stores: [],
         rssCampaign: false,
-        rssShowPreview: false
+        rssShowPreview: false,
+        fileServerImagesURL: "https://app2.dopplerfiles.com"
       };
       return $q.resolve(msEditorSettings);
     }


### PR DESCRIPTION
The migration to version v1.0.1-build169 needs a file server setting in order to keep working the social follow component 