### PR TITLE
DD-144 Change plan selector slider

### DIFF
--- a/src/spec/billing_spec.js
+++ b/src/spec/billing_spec.js
@@ -736,27 +736,6 @@ describe('Billing Page', () => {
 
     // Assert
     expect(billingPage.getBasicButtonText()).toBe('CHANGE PLAN');
-    expect(billingPage.isProPlanButtonDisabled()).toBeTruthy();
-
-    done();
-  });
-
-  it('should show the new box for Pro and premium plan', (done) => {
-
-    // Arrange
-    beginAuthenticatedSession();
-    browser.get('/#/settings/my-plan?plan=PLAN-60K');
-    setupSamplePlanInfoResponse();
-    setupSamplePlansResponse();
-    var billingPage = new BillingPage();
-    billingPage.clickUpgradeButtonToDisplayPricingChart();
-    expect(billingPage.isSliderLoaded()).toBeTruthy();
-
-    //Act
-    billingPage.clickFirstSliderTick();
-
-    // Assert
-    expect(billingPage.isRightPlanBoxDisplayed()).toBe(true);
 
     done();
   });

--- a/src/spec/settings_spec.js
+++ b/src/spec/settings_spec.js
@@ -552,7 +552,7 @@ describe('Settings Page', () => {
       expect(myPlanPage.isPricingChartContainerDisplayed()).toBeTruthy();
   });
 
-  it('should show change plan buttons enabled', () => {
+  it('should show change plan button enabled', () => {
     //Arrange
     beginAuthenticatedSession();
     browser.addMockModule('descartableModule2', ()=> angular
@@ -576,10 +576,10 @@ describe('Settings Page', () => {
 
       //Assert
       expect(myPlanPage.isDisabledBasicPlanChangeButton()).not.toMatch('button--disabled');
-      expect(myPlanPage.isDisabledProPlanChangeButton()).not.toMatch('button--disabled');
+
   });
 
-  it('should show change plan buttons disabled', () => {
+  it('should show change plan button disabled', () => {
     //Arrange
     beginAuthenticatedSessionForUpgradePlan();
     browser.addMockModule('descartableModule2', ()=> angular
@@ -603,10 +603,10 @@ describe('Settings Page', () => {
 
       //Assert
       expect(myPlanPage.isDisabledBasicPlanChangeButton()).toMatch('button--disabled');
-      expect(myPlanPage.isDisabledProPlanChangeButton()).toMatch('button--disabled');
+
   });
 
-  it('should show only one change plan button on each plan\'s side with require domain validation passed', () => {
+  it('should show only one change plan button with require domain validation passed', () => {
     //Arrange
     beginAuthenticatedSessionForUpgradePlan();
     browser.addMockModule('descartableModule2', ()=> angular
@@ -630,7 +630,7 @@ describe('Settings Page', () => {
 
       //Assert
       expect(myPlanPage.isOnlyOneButtonInBasicPlanContainer()).toEqual(1);
-      expect(myPlanPage.isOnlyOneButtonInProPlanContainer()).toEqual(1);
+
   });
 
   it('should show all the validation messages to upgrade the plan', () => {

--- a/src/wwwroot/controllers/PlanCtrl.js
+++ b/src/wwwroot/controllers/PlanCtrl.js
@@ -108,32 +108,13 @@
       
       vm.ipsPlanCount = pro ? pro.ips_count : 0;
 
-      if (!basic) {
-        vm.showPremiumPlanBox = true;
+      vm.includesIp = false;        
 
-        vm.leftPlanName = pro.name;
-        vm.leftPlanPrice = pro.fee + (pro.ips_count * pro.cost_by_ip || 0);
-        vm.leftCostEmail = pro.extra_delivery_cost;
-        vm.disableLeftPlan = isCurrentPlan(pro);
-
-        vm.rightPlanName = 'Premium';
-        vm.rightCostEmail = pro.extra_delivery_cost;
-        vm.disableRightPlan = false;
-      } else {
-        vm.showPremiumPlanBox = false;        
-
-        vm.leftPlanName = basic.name;
-        vm.leftPlanPrice = basic.fee;
-        vm.leftCostEmail = basic.extra_delivery_cost;
-        vm.disableLeftPlan = isCurrentPlan(basic);
-
-        if (pro) {
-          vm.rightPlanName = pro.name;
-          vm.rightPlanPrice = pro.fee + (pro.ips_count * pro.cost_by_ip || 0);
-          vm.rightCostEmail = pro.extra_delivery_cost;
-          vm.disableRightPlan = isCurrentPlan(pro);
-        }
-      }
+      vm.PlanName = basic ? basic.name : pro.name;
+      vm.PlanPrice = basic ? basic.fee : pro.fee + (pro.ips_count * pro.cost_by_ip || 0);
+      vm.CostEmail = basic ? basic.extra_delivery_cost : pro.extra_delivery_cost;
+      vm.disablePlan = basic ? isCurrentPlan(basic) : isCurrentPlan(pro);
+      vm.includesIp = !basic;
     }
 
     function loadSlider() {

--- a/src/wwwroot/partials/settings/my-plan.html
+++ b/src/wwwroot/partials/settings/my-plan.html
@@ -85,17 +85,17 @@
       </svg></div>
     </div>
     <div class="section--wrapper plan--box-container">
-      <ul ng-class="!vm.showPremiumPlanBox ? 'basic':'pro'">
+      <ul ng-class="!vm.includesIp ? 'basic':'pro'">
         <li class="special">
-          <span ng-if="!vm.showPremiumPlanBox">{{ 'basic_plan_text' | translate }} {{ vm.leftPlanName | translate }}</span>
-          <span ng-if="vm.showPremiumPlanBox">{{ 'pro_plan_text' | translate }} {{ vm.leftPlanName | translate }}</span>
+          <span>{{ vm.PlanName | translate }}</span>
         </li>
-        <li>{{'cost_email' | translate}} {{vm.currency | translate}} {{vm.leftCostEmail | number:5}}</li>
+        <li>{{'cost_email' | translate}} {{vm.currency | translate}} {{vm.CostEmail | number:5}}</li>
         <li>{{'attr_api' | translate}}</li>
         <li>{{'attr_dkim' | translate}}</li>
         <li>{{'attr_metrics_and_reports' | translate}}</li>
         <li class="strong">
-          <span class="hidden-feature" ng-class="vm.showPremiumPlanBox ? 'show':''">{{'attr_dedicated_ip' | translate}} {{vm.ipsPlanCount}}</span>
+          <span class="hidden-feature" ng-class="vm.includesIp ? 'show':''">{{'attr_dedicated_ip' | translate}}
+            {{vm.ipsPlanCount}}</span>
         </li>
         <li>
           <span class="hidden-feature">
@@ -112,47 +112,15 @@
           </span>
         </li>
         <li class="strong">
-          <h2 id="planPriceBig" class="special plan--price-big">{{vm.currency | translate}} {{vm.leftPlanPrice | number:2 | numberFormat}}</h2>
-          <a ng-class="!vm.disableLeftPlan  && vm.isValidUpgradeablePlan() ? 'show':''" class="hidden-feature-by-display button button--small" href="#/settings/billing?plan={{vm.leftPlanName}}">{{'change_plan' | translate}}</a>
-          <a ng-class="vm.disableLeftPlan && vm.isValidUpgradeablePlan()? 'show':''" class="button button--small button--disabled hidden-feature-by-display">{{'change_plan' | translate}}</a>
-          <a ng-class="vm.isValidUpgradeablePlan() ? '':'show'" class="button button--small button--disabled hidden-feature-by-display">{{'change_plan' | translate}}</a>
-        </li>
-      </ul>
-      <ul ng-class="!vm.showPremiumPlanBox ? 'pro':'premium'">
-        <li class="special">
-          <span ng-if="!vm.showPremiumPlanBox">{{ 'pro_plan_text' | translate }} {{ vm.leftPlanName | translate }}</span>
-          <span ng-if="vm.showPremiumPlanBox">{{ 'premium_plan_text' | translate }} {{ vm.leftPlanName | translate }}</span>
-        </li>
-        <li>{{'cost_email' | translate}} {{vm.currency | translate}} {{vm.rightCostEmail | number:5}}</li>
-        <li>{{'attr_api' | translate}}</li>
-        <li>{{'attr_dkim' | translate}}</li>
-        <li>{{'attr_metrics_and_reports' | translate}}</li>
-        <li class="strong">
-          <span ng-if="!vm.showPremiumPlanBox">{{'attr_dedicated_ip' | translate}} {{vm.ipsPlanCount}}</span>
-          <span ng-if="vm.showPremiumPlanBox">{{'attr_dedicated_ip_premium' | translate}}</span>
-        </li>
-        <li class="strong">
-          <span class="hidden-feature" ng-class="vm.showPremiumPlanBox ? 'show':''">
-            {{'account_manager_text' | translate}}
-            <svg class="icon star-icon">
-              <use xlink:href="/images/sprite.svg#doppler-icon-star-icon"></use>
-            </svg>
-          </span>
-        </li>
-        <li>
-          <span class="hidden-feature" ng-class="vm.showPremiumPlanBox ? 'show':''">
-            {{'vip_support_text' | translate}}
-            <svg class="icon star-icon">
-              <use xlink:href="/images/sprite.svg#doppler-icon-star-icon"></use>
-            </svg>
-          </span>
-        </li>
-        <li>
-          <h2 ng-class="!vm.showPremiumPlanBox ? 'show':''" class="hidden-feature special plan--price-big">{{vm.currency | translate}} {{vm.rightPlanPrice | number:2 | numberFormat}}</h2>
-          <a ng-class="!vm.disableRightPlan && !vm.showPremiumPlanBox && vm.isValidUpgradeablePlan() ? 'show':''" class="hidden-feature-by-display button button--small" href="#/settings/billing?plan={{vm.rightPlanName}}">{{'change_plan' | translate}}</a>
-          <a ng-class="!vm.disableRightPlan && vm.showPremiumPlanBox ? 'show':''" class="hidden-feature-by-display button button--small" target="_blank" href="https://www.dopplerrelay.com/contacto">{{'contact_us_text' | translate}}</a>
-          <a ng-class="vm.disableRightPlan ? 'show':''" class="button button--small button--disabled hidden-feature-by-display">{{'change_plan' | translate}}</a>
-          <a ng-class="!vm.disableRightPlan && !vm.showPremiumPlanBox && !vm.isValidUpgradeablePlan() ? 'show':''" class="button button--small button--disabled hidden-feature-by-display">{{'change_plan' | translate}}</a>
+          <h2 id="planPriceBig" class="special plan--price-big">{{vm.currency | translate}} {{vm.PlanPrice |
+            number:2 | numberFormat}}</h2>
+          <a ng-class="!vm.disablePlan  && vm.isValidUpgradeablePlan() ? 'show':''"
+            class="hidden-feature-by-display button button--small"
+            href="#/settings/billing?plan={{vm.PlanName}}">{{'change_plan' | translate}}</a>
+          <a ng-class="vm.disablePlan && vm.isValidUpgradeablePlan()? 'show':''"
+            class="button button--small button--disabled hidden-feature-by-display">{{'change_plan' | translate}}</a>
+          <a ng-class="vm.isValidUpgradeablePlan() ? '':'show'"
+            class="button button--small button--disabled hidden-feature-by-display">{{'change_plan' | translate}}</a>
         </li>
       </ul>
       <div>

--- a/src/wwwroot/styles/views/_settings.scss
+++ b/src/wwwroot/styles/views/_settings.scss
@@ -397,9 +397,9 @@
   .plan--box-container{
     padding-top: 5em;
     ul {
-      padding: 0; 
-      margin: auto; 
-      display: inline-block;
+      padding: 0;
+      margin: auto;
+      display: block;
       @extend .transition--default;
       width: 47.4%;
       .special{
@@ -437,7 +437,6 @@
         }
       }
     }
-    ul:first-of-type { margin-right: 4%;}
     li.special {
       color: $suit-background-default;
       width: 100%;


### PR DESCRIPTION
Hello team, this PR is aimed to make come changes on the plans available for customers of Relay, removing the `Premium`, `Pro` and `Basic` distinctions from the plans. For this purpose the second card was eliminated leaving only one central card (the looks of it are pending a review from the UX team)

How it would be now
![relay nuevo](https://user-images.githubusercontent.com/44210512/108847570-9e007c00-75be-11eb-8277-07961aa46431.gif)

How it was
![relay actual](https://user-images.githubusercontent.com/44210512/108847555-9b9e2200-75be-11eb-8792-fbca1b68d7c3.gif)
